### PR TITLE
Bump Go version to 1.19

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,19 +13,25 @@ permissions:
   pull-requests: read
 jobs:
   golangci:
-    strategy:
-      matrix:
-        go-version: [1.18.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install asdf dependencies
+        uses: asdf-vm/actions/install@v1
+
+      - name: Read the right version of golangci-lint
+        id: golangci_lint_version
+        run: |
+          golangCiLintVersion=$(grep '^golangci-lint ' .tool-versions | awk '{print $2}')
+          echo "::set-output name=golangCiLintVersion::${golangCiLintVersion}"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: "v1.48.0"
+          version: v${{ steps.golangci_lint_version.outputs.golangCiLintVersion }}
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Read the right version of Go
+        id: golang_version
+        run: |
+          golangVersion=$(grep '^golang ' .tool-versions | awk '{print $2}')
+          echo "::set-output name=golangVersion::${golangVersion}"
+
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: "1.18"
+          go_version: ${{ steps.golang_version.outputs.golangVersion }}

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-golang 1.18.1
+golang 1.19.1
+golangci-lint 1.49.0

--- a/README.md
+++ b/README.md
@@ -54,21 +54,33 @@ Or
 
 ## Working with the source code
 
-- If not done already, download and install [Go](https://go.dev/doc/install) to build the project. This project has been built with Go 1.18.
-- Clone the repository and install the local version.
+1. Clone the repository:
+
+```
+git clone https://github.com/rm3l/gh-dev-branch
+cd gh-dev-branch
+```
+
+2. Download and install [Go](https://go.dev/doc/install) to build the project.
+   Or if you are already using the [asdf](https://asdf-vm.com/) version manager, you can just run `asdf install` to install all the necessary tools (declared in the [.tool-versions](.tool-versions) file).
+
+3. Install the local version of this extension; `gh` symlinks to your local source code directory.
 
 ```bash
-git clone https://github.com/rm3l/gh-dev-branch && cd gh-dev-branch
-
 # Install the local version
 gh extension install .
+```
 
-# At this point, you can start using it
-gh dev-branch <my-issue-number>
+4. At this point, you can start using it:
 
-# To see changes in the code as you develop,
-# simply build and use the extension:
-go build && gh dev-branch <my-issue-number>
+```bash
+gh dev-branch <my-issue-number> [-repo <my_org/my_repo>]
+```
+
+5. To see changes in the code as you develop, simply build and use the extension
+
+```bash
+go build && gh dev-branch <my-issue-number> [-repo <my_org/my_repo>]
 ```
 
 ## Contribution Guidelines

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rm3l/gh-dev-branch
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cli/go-gh v0.1.0


### PR DESCRIPTION
- chore: Update to Go 1.19
- chore: Update .tool-versions with the expected versions
- chore(CI): Extract tool versions from .tool-versions
- chore: Update README
